### PR TITLE
fromIntWith, toIntWith, compileWith implemented. delta-generators/tests refactored.

### DIFF
--- a/src/lambda-calculus.js
+++ b/src/lambda-calculus.js
@@ -63,22 +63,25 @@ class A {
 
 const Y = new L("f",new A(new L("x",new A(new V("f"),new A(new V("x"),new V("x")))),new L("x",new A(new V("f"),new A(new V("x"),new V("x"))))));
 
-function fromInt(n) {
-  if ( config.numEncoding === "Church" )
-    return new L("s", new L("z", Array(n).fill().reduce( s => new A(new V("s"), s), new V("z")) ));
-  else if ( config.numEncoding === "Scott" )
-    return new Array(n).fill().reduce( v => new L('_', new L('f', new A(new V('f'), v))), new L('z', new L('_', new V('z'))) );
-  else if ( config.numEncoding === "BinaryScott" )
-    return n.toString(2).replace(/^0$/,'').split("").reduce( (a,c) => new L('_', new L('f', new L('t', new A(new V( c==='1' ? 't' : 'f' ), a)))), new L('z', new L('_', new L('_', new V('z')))) );
-  else if ( config.numEncoding === "None" )
-    throw EvalError("This kata does not allow for number constants");
-  else
-    return config.numEncoding.fromInt(n); // Custom encoding
+function fromInt(n) { return fromIntWith()(n); }
+
+function fromIntWith(cfg={}) {
+  const {numEncoding,verbosity} = Object.assign( {}, config, cfg );
+  return function fromInt(n) {
+    if ( numEncoding === "Church" )
+      return new L("s", new L("z", Array(n).fill().reduce( s => new A(new V("s"), s), new V("z")) ));
+    else if ( numEncoding === "Scott" )
+      return new Array(n).fill().reduce( v => new L('_', new L('f', new A(new V('f'), v))), new L('z', new L('_', new V('z'))) );
+    else if ( numEncoding === "BinaryScott" )
+      return n.toString(2).replace(/^0$/,'').split("").reduce( (a,c) => new L('_', new L('f', new L('t', new A(new V( c==='1' ? 't' : 'f' ), a)))), new L('z', new L('_', new L('_', new V('z')))) );
+    else if ( numEncoding === "None" )
+      throw EvalError("This kata does not allow for number constants");
+    else
+      return numEncoding.fromInt(n); // Custom encoding
+  } ;
 }
 
-function toInt(term) {
-  return toIntWith()(term);
-}
+function toInt(term) { return toIntWith()(term); }
 
 function toIntWith(cfg={}) {
   const {numEncoding,verbosity} = Object.assign( {}, config, cfg );
@@ -100,164 +103,164 @@ function toIntWith(cfg={}) {
         return numEncoding.toInt(term);
       }
     } catch (e) {
-      console.error("Term is not a number (or encoding is wrong)");
+      if ( verbosity >= "Concise" ) console.error("toInt: Term is not a number (or encoding is wrong)");
       throw EvalError("Term is not a number (or encoding is wrong)");
     }
   } ;
 }
 
-function compile(code) {
-  // Capture current settings // rewrite for compileWith()
-  const purity = config.purity;
-  const numEncoding = config.numEncoding;
-  const verbosity = config.verbosity;
+function compile(code) { return compileWith()(code); }
 
-  function compile(env,code) {
-    function wrap(name,term) {
-      const FV = term.free(); FV.delete("()");
-      if ( purity === "Let" )
-        return Array.from(FV).reduce( (tm,nm) => { if ( nm in env ) return new A( new L(nm,tm), env[nm] ); else { console.error(name,"=",term.toString()); throw new ReferenceError(`undefined free variable ${ nm }`); } } , term );
-      else if ( purity==="LetRec" )
-        return Array.from(FV).reduce( (tm,nm) => { // this wraps terms in a snapshot of their environment at the moment of defining // TODO: tidy it
-            if ( nm === name )
-              return tm;
-            else if ( nm in env )
-              return new A( new L(nm,tm), env[nm] );
-            else {
-              if ( config.verbosity > "Calm" ) console.error(`undefined free variable ${ nm } while defining ${ name } = ${ term }`);
-              throw new ReferenceError(`undefined free variable ${ nm }`);
+function compileWith(cfg={}) {
+  const {numEncoding,purity,verbosity} = Object.assign( {}, config, cfg );
+  return function compile(code=fs.readFileSync("./solution.txt", "utf8")) {
+    function compile(env,code) {
+      function wrap(name,term) {
+        const FV = term.free(); FV.delete("()");
+        if ( purity === "Let" )
+          return Array.from(FV).reduce( (tm,nm) => { if ( nm in env ) return new A( new L(nm,tm), env[nm] ); else { console.error(name,"=",term.toString()); throw new ReferenceError(`undefined free variable ${ nm }`); } } , term );
+        else if ( purity==="LetRec" )
+          return Array.from(FV).reduce( (tm,nm) => { // this wraps terms in a snapshot of their environment at the moment of defining // TODO: tidy it
+              if ( nm === name )
+                return tm;
+              else if ( nm in env )
+                return new A( new L(nm,tm), env[nm] );
+              else {
+                if ( config.verbosity >= "Concise" ) console.error(`undefined free variable ${ nm } while defining ${ name } = ${ term }`);
+                throw new ReferenceError(`undefined free variable ${ nm }`);
+              }
             }
+          , FV.has(name) ? new A(Y,new L(name,term)) : term
+          );
+        else if ( purity==="PureLC" )
+          if ( FV.size ) {
+            if ( config.verbosity >= "Concise" ) console.error(`unresolvable free variable(s) ${ Array.from(FV) } while defining ${ name } = ${ term }`);
+            throw new EvalError(`unresolvable free variable(s) ${ Array.from(FV) }: all expressions must be closed in PureLC mode`);
+          } else
+            return term;
+        else
+          throw new RangeError(`config.purity: unknown setting "${ purity }"`);
+      }
+      const letters = /[a-z]/i;
+      const digits = /\d/;
+      const identifierChars = /[-'\w]/;
+      const whitespace = /\s/;
+      function error(i,msg) {
+        console.error(code);
+        console.error(' '.repeat(i) + '^');
+        console.error(msg + " at position " + i);
+        throw new SyntaxError;
+      }
+      function sp(i) { while ( whitespace.test( code[i] || "" ) ) i++; return i; }
+      const expect = c => function(i) { return code[i]===c ? sp(i+1) : 0 ; } ;
+      function name(i) {
+        if ( code[i]==='_' ) {
+          while ( identifierChars.test( code[i] || "" ) ) i++;
+          return [sp(i),"_"];
+        } else if ( letters.test( code[i] || "" ) ) {
+          let j = i+1;
+          while ( identifierChars.test( code[j] || "" ) ) j++;
+          return [sp(j),code.slice(i,j)];
+        } else
+          return null;
+      }
+      function n(i) {
+        if ( digits.test(code[i]) ) {
+          let j = i+1;
+          while ( digits.test(code[j]) ) j++;
+          return [sp(j),fromInt(Number(code.slice(i,j)))];
+        } else
+          return null;
+      }
+      function v(i) {
+        const r = name(i);
+        if ( r ) {
+          const [j,name] = r;
+          return [j,new V(name)];
+        } else
+          return null;
+      }
+      function l(i) {
+        const j = expect('\\')(i);
+        if ( j ) {
+          let arg, args = [];
+          let k = j;
+          while ( arg = name(k) ) {
+            [k,arg] = arg;
+            args.push(arg);
           }
-        , FV.has(name) ? new A(Y,new L(name,term)) : term
-        );
-      else if ( purity==="PureLC" )
-        if ( FV.size ) {
-          if ( config.verbosity > "Calm" ) console.error(`unresolvable free variable(s) ${ Array.from(FV) } while defining ${ name } = ${ term }`);
-          throw new EvalError(`unresolvable free variable(s) ${ Array.from(FV) }: all expressions must be closed in PureLC mode`);
+          if ( args.length ) {
+            const l = expect('.')(k) || error(k,"lambda: expected '.'") ;
+            const [m,body] = term(l) || error(l,"lambda: expected a lambda calculus term") ;
+            return [ m, args.reduceRight( (body,arg) => new L(arg,body) , body ) ];
+          } else
+            error(k,"lambda: expected at least one named argument");
         } else
-          return term;
-      else
-        throw new RangeError(`config.purity: unknown setting "${ purity }"`);
-    }
-    const letters = /[a-z]/i;
-    const digits = /\d/;
-    const identifierChars = /[-'\w]/;
-    const whitespace = /\s/;
-    function error(i,msg) {
-      console.error(code);
-      console.error(' '.repeat(i) + '^');
-      console.error(msg + " at position " + i);
-      throw new SyntaxError;
-    }
-    function sp(i) { while ( whitespace.test( code[i] || "" ) ) i++; return i; }
-    const expect = c => function(i) { return code[i]===c ? sp(i+1) : 0 ; } ;
-    function name(i) {
-      if ( code[i]==='_' ) {
-        while ( identifierChars.test( code[i] || "" ) ) i++;
-        return [sp(i),"_"];
-      } else if ( letters.test( code[i] || "" ) ) {
-        let j = i+1;
-        while ( identifierChars.test( code[j] || "" ) ) j++;
-        return [sp(j),code.slice(i,j)];
-      } else
-        return null;
-    }
-    function n(i) {
-      if ( digits.test(code[i]) ) {
-        let j = i+1;
-        while ( digits.test(code[j]) ) j++;
-        return [sp(j),fromInt(Number(code.slice(i,j)))];
-      } else
-        return null;
-    }
-    function v(i) {
-      const r = name(i);
-      if ( r ) {
-        const [j,name] = r;
-        return [j,new V(name)];
-      } else
-        return null;
-    }
-    function l(i) {
-      const j = expect('\\')(i);
-      if ( j ) {
-        let arg, args = [];
-        let k = j;
-        while ( arg = name(k) ) {
-          [k,arg] = arg;
-          args.push(arg);
-        }
-        if ( args.length ) {
-          const l = expect('.')(k) || error(k,"lambda: expected '.'") ;
-          const [m,body] = term(l) || error(l,"lambda: expected a lambda calculus term") ;
-          return [ m, args.reduceRight( (body,arg) => new L(arg,body) , body ) ];
-        } else
-          error(k,"lambda: expected at least one named argument");
-      } else
-        return null;
-    }
-    function a(i) {
-      let q, r = [];
-      let j = i;
-      while ( q = paren_d(term)(j) || l(j) || v(j) || n(j) ) {
-        [j,q] = q;
-        r.push(q);
+          return null;
       }
-      if ( r.length )
-        return [ j, r.reduce( (z,term) => new A(z,term) ) ];
-      else
-        return null;
+      function a(i) {
+        let q, r = [];
+        let j = i;
+        while ( q = paren_d(term)(j) || l(j) || v(j) || n(j) ) {
+          [j,q] = q;
+          r.push(q);
+        }
+        if ( r.length )
+          return [ j, r.reduce( (z,term) => new A(z,term) ) ];
+        else
+          return null;
+      }
+      const paren_d = inner => function(i) {
+        const j = expect('(')(i);
+        if ( j ) {
+          const q = inner(j);
+          if ( q ) {
+            const [k,r] = q;
+            const l = expect(')')(k) || error(k,"paren_d: expected ')'") ;
+            return [l,r];
+          } else {
+            const k = expect(')')(j) || error(j,"paren_d: expected ')'") ;
+            return [k,new V("()")];
+          }
+        } else
+          return null;
+      } ;
+      const term = a;
+      function defn(i) {
+        const [j,nm] = name(i)   || error(i,"defn: expected a name") ;
+        const k = expect('=')(j) || error(j,"defn: expected '='") ;
+        const [l,tm] = term(k)   || error(k,"defn: expected a lambda calculus term") ;
+        return [l,[nm,tm]];
+      }
+      const [i,r] = defn(0);
+      if ( i===code.length ) {
+        const [name,term] = r;
+        return Object.assign( env, { [name]: wrap(name,term) } );
+      } else
+        error(i,"defn: incomplete parse");
     }
-    const paren_d = inner => function(i) {
-      const j = expect('(')(i);
-      if ( j ) {
-        const q = inner(j);
-        if ( q ) {
-          const [k,r] = q;
-          const l = expect(')')(k) || error(k,"paren_d: expected ')'") ;
-          return [l,r];
+    const env = code.replace( /#.*$/gm, "" )
+                    .replace( /\n(?=\s)/g, "" )
+                    .split( '\n' )
+                    .filter( term => /\S/.test(term) )
+                    .reduce(compile,{})
+                    ;
+    for ( const [name,term] of Object.entries(env) )
+      Object.defineProperty( env, name, { get() { return env._cache.has(name) ? env._cache.get(name) : env._cache.set( name, evalLC(term) ).get(name) ; } } );
+    env._cache = new Map;
+    const envHandler = {
+      get: function (target, property) {
+        // Custom undefined error when trying to access functions not defined in environment
+        const result = Reflect.get(target, property);
+        if (result === undefined) {
+          throw ReferenceError(`${property} is not defined.`);
         } else {
-          const k = expect(')')(j) || error(j,"paren_d: expected ')'") ;
-          return [k,new V("()")];
+          return result;
         }
-      } else
-        return null;
-    } ;
-    const term = a;
-    function defn(i) {
-      const [j,nm] = name(i)   || error(i,"defn: expected a name") ;
-      const k = expect('=')(j) || error(j,"defn: expected '='") ;
-      const [l,tm] = term(k)   || error(k,"defn: expected a lambda calculus term") ;
-      return [l,[nm,tm]];
-    }
-    const [i,r] = defn(0);
-    if ( i===code.length ) {
-      const [name,term] = r;
-      return Object.assign( env, { [name]: wrap(name,term) } );
-    } else
-      error(i,"defn: incomplete parse");
-  }
-  const env = code.replace( /#.*$/gm, "" )
-                  .replace( /\n(?=\s)/g, "" )
-                  .split( '\n' )
-                  .filter( term => /\S/.test(term) )
-                  .reduce(compile,{})
-                  ;
-  for ( const [name,term] of Object.entries(env) )
-    Object.defineProperty( env, name, { get() { return env._cache.has(name) ? env._cache.get(name) : env._cache.set( name, evalLC(term) ).get(name) ; } } );
-  env._cache = new Map;
-  const envHandler = {
-    get: function (target, property) {
-      // Custom undefined error when trying to access functions not defined in environment
-      const result = Reflect.get(target, property);
-      if (result === undefined) {
-        throw ReferenceError(`${property} is not defined.`);
-      } else {
-        return result;
       }
-    }
-  };
-  return new Proxy(env, envHandler);
+    };
+    return new Proxy(env, envHandler);
+  } ;
 }
 
 function evalLC(term) {
@@ -318,7 +321,11 @@ Object.defineProperty( Function.prototype, "valueOf", { value: function valueOf(
 Object.defineProperty( Function.prototype, "decoded", { get() { return this.valueOf(); }, enumerable: true } );
 
 exports.config = config;
-exports.compile = text => compile(text === undefined ? fs.readFileSync("./solution.txt", "utf8") : text);
-exports.T = new L('a', new L('b', new V('a')));
-exports.F = new L('a', new L('b', new V('b')));
+exports.compile = compile;
+exports.compileWith = compileWith;
+exports.fromInt = fromInt;
+exports.fromIntWith = fromIntWith;
 exports.toInt = toInt;
+exports.toIntWith = toIntWith;
+exports.T = new L('a', new L('b', new V('a'))); // to be removed
+exports.F = new L('a', new L('b', new V('b'))); // to be removed


### PR DESCRIPTION
refactored `toInt`, `fromInt` and `compile` to `*With`; added wrappers for `Without`; added exports, also for `fromInt`.

refactored `delta-generators/test.js` to use `fromIntWith` and friends

testing seems to work now with varying encodings among different tests.

if you call `compile` outside `describe / it`, it takes the current encoding - but you've just set that.
if you call `toInt` inside of `describe / it`, you can define it with `toIntWith(LC.config)` ( you just set `LC.config` - might as well use it ). same for `fromInt` ( why wasn't that exported? ) and `compile`, but `compile` probably won't happen as often.